### PR TITLE
Use the preferred style for iOS 13

### DIFF
--- a/CTFeedbackSwift/FeedbackViewController.swift
+++ b/CTFeedbackSwift/FeedbackViewController.swift
@@ -45,7 +45,11 @@ public class FeedbackViewController: UITableViewController {
     public init(configuration: FeedbackConfiguration) {
         self.configuration = configuration
 
-        super.init(style: .grouped)
+        if #available(iOS 13, *) {
+            super.init(style: .insetGrouped)
+        } else {
+            super.init(style: .grouped)
+        }
 
         wireframe = FeedbackWireframe(viewController: self,
                                       transitioningDelegate: self,
@@ -61,6 +65,7 @@ public class FeedbackViewController: UITableViewController {
         tableView.rowHeight = UITableView.automaticDimension
         tableView.estimatedRowHeight = 44.0
         tableView.keyboardDismissMode = .onDrag
+        tableView.cellLayoutMarginsFollowReadableWidth = true
 
         cellFactories.forEach(tableView.register(with:))
         updateDataSource(configuration: configuration)


### PR DESCRIPTION
This pull request does two things:

- Use the new style for iOS 13. 
- And enables readable width for cells so that the feedback tableview will look better in iPadOS and macCatalyst.

| Before (iOS) | After (iOS) |
| --- | --- |
| <img width="320" alt="before" src="https://user-images.githubusercontent.com/4032674/78987469-b6aba300-7b60-11ea-9980-0f29361b0e8d.png"> | <img width="320" alt="after" src="https://user-images.githubusercontent.com/4032674/78987424-8e23a900-7b60-11ea-8a56-24664389129e.png"> |
| Before (macCatalyst) | After (macCatalyst) |
| <img width="450" alt="before_mac" src="https://user-images.githubusercontent.com/4032674/78987681-44878e00-7b61-11ea-98e7-bfbf2706e4d1.png"> | <img width="450" alt="after_mac" src="https://user-images.githubusercontent.com/4032674/78987692-4d785f80-7b61-11ea-96ec-386e784aab54.png"> |

