### PR TITLE
Handle photo and camera auth status on main thread

### DIFF
--- a/CTFeedbackSwift/FeedbackViewController.swift
+++ b/CTFeedbackSwift/FeedbackViewController.swift
@@ -130,14 +130,22 @@ extension FeedbackViewController {
         case _ as TopicItem:
             wireframe.showTopicsView(with: feedbackEditingService)
         case _ as AttachmentItem:
-            wireframe.showAttachmentActionSheet(authorizePhotoLibrary: { completion in
-                PHPhotoLibrary.requestAuthorization { status in completion(status == .authorized) }
-            },
-                                                authorizeCamera: { completion in
-                                                    AVCaptureDevice.requestAccess(for: AVMediaType.video,
-                                                                                  completionHandler: completion)
-                                                },
-                                                deleteAction: attachmentDeleteAction)
+            wireframe.showAttachmentActionSheet(
+                authorizePhotoLibrary: { completion in
+                    PHPhotoLibrary.requestAuthorization { status in
+                        DispatchQueue.main.async {
+                            completion(status == .authorized)
+                        }
+                    }
+                },
+                authorizeCamera: { completion in
+                    AVCaptureDevice.requestAccess(for: AVMediaType.video) { result in
+                        DispatchQueue.main.async {
+                            completion(result)
+                        }
+                    }
+                },
+                deleteAction: attachmentDeleteAction)
         default: ()
         }
         tableView.deselectRow(at: indexPath, animated: true)


### PR DESCRIPTION
According to the Apple documentation, request access permission for camera and photo will have a completion handle which will be invoked on non-main thread.

For photos:
> Photos may call your handler block on an arbitrary serial queue. If your handler needs to interact with user interface elements, dispatch such work to the main queue.

For camera:
> The completion handler is called on an arbitrary dispatch queue. It is the client's responsibility to ensure that any UIKit-related updates are called on the main queue or main thread as a result.

If we use UIKit related classes and methods inside those blocks directly, an exception will be raised.