### PR TITLE
Fix compile warnings for SPM

### DIFF
--- a/CTFeedbackSwift/FeedbackViewController.swift
+++ b/CTFeedbackSwift/FeedbackViewController.swift
@@ -148,9 +148,11 @@ extension FeedbackViewController {
                     }
                 },
                 authorizeCamera: { completion in
-                    AVCaptureDevice.requestAccess(for: AVMediaType.video) { result in
-                        DispatchQueue.main.async {
-                            completion(result)
+                    if #available(iOS 7.0, macCatalyst 14.0, *) {
+                        AVCaptureDevice.requestAccess(for: .video) { result in
+                            DispatchQueue.main.async {
+                                completion(result)
+                            }
                         }
                     }
                 },

--- a/CTFeedbackSwift/FeedbackWireframe.swift
+++ b/CTFeedbackSwift/FeedbackWireframe.swift
@@ -106,7 +106,7 @@ extension FeedbackWireframe: FeedbackWireframeProtocol {
 
         alertController.addAction(UIAlertAction(title: CTLocalizedString("CTFeedback.Cancel"),
                                                 style: .cancel))
-        let screenSize = UIScreen.main.bounds
+
         alertController.popoverPresentationController?.sourceView = viewController?.view
         alertController.popoverPresentationController?.sourceRect = cellRect
         alertController.popoverPresentationController?.permittedArrowDirections = .any
@@ -181,10 +181,8 @@ private extension FeedbackWireframe {
         let alert = UIAlertController(title: .none,
                                       message: CTLocalizedString("CTFeedback.requiredLibraryAccess"),
                                       preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { action in
-            if let url = URL(string: UIApplication.openSettingsURLString) {
-                UIApplication.shared.openURL(url)
-            }
+        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { [unowned self] action in
+            self.redirectToSettings()
         }))
         viewController?.present(alert, animated: true)
     }
@@ -193,11 +191,19 @@ private extension FeedbackWireframe {
         let alert = UIAlertController(title: .none,
                                       message: CTLocalizedString("CTFeedback.requiredCameraAccess"),
                                       preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { action in
-            if let url = URL(string: UIApplication.openSettingsURLString) {
-                UIApplication.shared.openURL(url)
-            }
+        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { [unowned self] action in
+            self.redirectToSettings()
         }))
         viewController?.present(alert, animated: true)
+    }
+
+    private func redirectToSettings() {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+
+        if #available(iOS 10.0, macCatalyst 13.0, *) {
+            UIApplication.shared.open(url)
+        } else {
+            UIApplication.shared.openURL(url)
+        }
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     defaultLocalization: "en",
     platforms: [
         // Some platform where run yours library
-        .iOS(.v10), .tvOS(.v10), .watchOS(.v4)
+        .iOS(.v10)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
@@ -16,6 +16,15 @@ let package = Package(
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-        .target(name: "CTFeedbackSwift", path: "CTFeedbackSwift")
+        .target(
+            name: "CTFeedbackSwift",
+            path: "CTFeedbackSwift",
+            exclude: [
+                "CTFeedbackSwift.h", "Info.plist",
+            ],
+            resources: [
+                .process("Resources"),
+            ]
+        )
     ]
 )


### PR DESCRIPTION
1. Remove watchOS, tvOS targets;
2. Add platform version check when using `AVCaptureDevice.requestAccess` (fix compile error);
3. Standalone method `redirectToSettings()` for open URL;
4. Add `exclude` and `resources` in SPM configuration (fix compile warnings).